### PR TITLE
Disable core commands, only migration commands

### DIFF
--- a/config/console.php
+++ b/config/console.php
@@ -8,6 +8,7 @@
 
 return [
   'id' => 'dbmigrator',
+  'enableCoreCommands' => false,
   'controllerMap' => [
     'migrate'=>[
       'class'=>'app\commands\MigrateController',


### PR DESCRIPTION
Отключаем команды, которые в миграторе не используются. Не будет сбивать с толку, выводятся только нужные команды
